### PR TITLE
docs: update README to include Netlify status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,7 @@
 
 This template should help get you started developing with Vue 3 in Vite.
 
-## Recommended IDE Setup
-
-[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur).
-
-## Type Support for `.vue` Imports in TS
-
-TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) to make the TypeScript language service aware of `.vue` types.
-
-## Customize configuration
-
-See [Vite Configuration Reference](https://vite.dev/config/).
+[![Netlify Status](https://api.netlify.com/api/v1/badges/c29c3926-7540-4828-b1d9-3e23e0283c53/deploy-status)](https://app.netlify.com/sites/wyciwyg/deploys)
 
 ## Project Setup
 


### PR DESCRIPTION
Remove outdated IDE setup and TypeScript support sections from the  README. Add a Netlify status badge to provide real-time deployment  status for the project. This improves clarity and keeps the  documentation concise and relevant.